### PR TITLE
fix to not link liblua and luac against libreadline

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,16 +21,17 @@ LUA_LIBS="-lm"
 # Check for readline
 READLINE_DEFS="#undef LUA_USE_READLINE"
 if test "x$use_readline" == "xyes"; then
-  AC_CHECK_LIB([readline], [readline], [], [use_readline=no], [-lncurses])
+  AC_CHECK_LIB([readline], [readline], [use_readline=yes], [use_readline=no], [-lncurses])
   AC_CHECK_HEADERS([readline/readline.h readline/history.h], [], [use_readline=no])
   if test "x$use_readline" == "xno"; then
     AC_MSG_WARN([readline headers could not be found, disabling readline support])
   else
     READLINE_DEFS="#define LUA_USE_READLINE"
-    LUA_LIBS="$LUA_LIBS -lreadline -lncurses"
+    READLINE_LIBS="$READLINE_LIBS -lreadline -lncurses"
   fi
 fi
 AC_SUBST(READLINE_DEFS)
+AC_SUBST(READLINE_LIBS)
 
 case "$host" in
   *-mingw*)  use_os=win32  ;;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,7 @@ liblua_la_SOURCES = \
 bin_PROGRAMS = lua luac
 
 lua_SOURCES = lua.c
-lua_LDADD = liblua.la @LUA_LIBS@
+lua_LDADD = liblua.la @LUA_LIBS@ @READLINE_LIBS@
 lua_DEPENDENCIES = liblua.la
 
 luac_SOURCES = luac.c print.c


### PR DESCRIPTION
There is no need to link liblua and luac against libreadline and friends.
It makes only sense to link the lua interpreter itself against readline
as it is the only one which can be run interactively.

Please note that by setting setting use_readline=yes as action-if-found
within the AC_CHECK_LIB macro, is a kind of workaround for not leaking
in -lreadline via the LIBS variable which is used globaly within Makefiles
when linking is done.

see: http://www.gnu.org/software/autoconf/manual/autoconf.html#Libraries

Note for the Fedora package maintainers:

Most probably you can omit following hackery within the lua.spec file by
using this patch.

http://pkgs.fedoraproject.org/gitweb/?p=lua.git;a=blob;f=lua.spec;h=8629717abaf46dbbe3497c26e39baaaf4dfa51e2;hb=HEAD#l61

-------------------snip--------------------------------------------------
make %{?_smp_mflags} LIBS="-lm -ldl" luac_LDADD="liblua.la -lm -ldl"
sed -i 's/-lreadline -lncurses //g' etc/lua.pc
-------------------snip--------------------------------------------------

Most probably there will be no need anymore for passing the make options
LIBS="-lm -ldl" luac_LDADD="liblua.la -lm -ldl".

Same applies to the mangling of the lua.pc file via sed, as the resulting
lua.pc file won't include '-lreadline -lncurses' anymore.
