### PR TITLE
lua.pc.in: add INSTALL_{L,C}MOD variables

### DIFF
--- a/etc/lua.pc.in
+++ b/etc/lua.pc.in
@@ -5,6 +5,9 @@ exec_prefix=${prefix}
 libdir= @libdir@
 includedir=${prefix}/include
 
+INSTALL_LMOD= ${prefix}/share/lua/${V}
+INSTALL_CMOD= ${prefix}/lib/lua/${V}
+
 Name: Lua
 Description: An Extensible Extension Language
 Version: ${R}


### PR DESCRIPTION
Note:

Most distributions are defining INSTALL_LMOD and INSTALL_CMOD within their
packaged pkg-config file of lua, because both are commonly used by third-party
Makefiles for figuring out where to install lua modules through pkg-config.

INSTALL_LMOD defines the path where to install pure lua modules
INSTALL_CMOD defines the path where to install compiled lua modules
